### PR TITLE
Adb toggling

### DIFF
--- a/library/src/main/java/com/friendoye/recyclerxray/AdbToggleReceiver.kt
+++ b/library/src/main/java/com/friendoye/recyclerxray/AdbToggleReceiver.kt
@@ -1,4 +1,4 @@
-package com.friendoye.recyclerxray.sample
+package com.friendoye.recyclerxray
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -7,7 +7,6 @@ import android.content.IntentFilter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import com.friendoye.recyclerxray.RecyclerXRay
 
 
 /**

--- a/sample/src/main/java/com/friendoye/recyclerxray/sample/AdbToggleReceiver.kt
+++ b/sample/src/main/java/com/friendoye/recyclerxray/sample/AdbToggleReceiver.kt
@@ -4,10 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.friendoye.recyclerxray.RecyclerXRay
 
 
-// TODO: Use LifecyclerOwner
 /**
  * To toggle RecyclerXRay use "adb shell am broadcast -a xray-toggle" command.
  * Inspired by this read: https://medium.com/@gpeal/reliable-hot-reload-on-android-27f14a80df60
@@ -15,12 +17,14 @@ import com.friendoye.recyclerxray.RecyclerXRay
 class AdbToggleReceiver(
     private val context: Context,
     private val intentAction: String = "xray-toggle"
-) : BroadcastReceiver() {
+) : BroadcastReceiver(), LifecycleObserver {
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun register() {
         context.registerReceiver(this, IntentFilter(intentAction))
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun unregister() {
         context.unregisterReceiver(this)
     }

--- a/sample/src/main/java/com/friendoye/recyclerxray/sample/AdbToggleReceiver.kt
+++ b/sample/src/main/java/com/friendoye/recyclerxray/sample/AdbToggleReceiver.kt
@@ -1,0 +1,31 @@
+package com.friendoye.recyclerxray.sample
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.friendoye.recyclerxray.RecyclerXRay
+
+
+// TODO: Use LifecyclerOwner
+/**
+ * To toggle RecyclerXRay use "adb shell am broadcast -a xray-toggle" command.
+ * Inspired by this read: https://medium.com/@gpeal/reliable-hot-reload-on-android-27f14a80df60
+ */
+class AdbToggleReceiver(
+    private val context: Context,
+    private val intentAction: String = "xray-toggle"
+) : BroadcastReceiver() {
+
+    fun register() {
+        context.registerReceiver(this, IntentFilter(intentAction))
+    }
+
+    fun unregister() {
+        context.unregisterReceiver(this)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        RecyclerXRay.toggleSecrets()
+    }
+}

--- a/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
+++ b/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
@@ -10,6 +10,8 @@ import com.friendoye.recyclerxray.sample.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
+    private val adbToggleReceiver = AdbToggleReceiver(this)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val binding = ActivityMainBinding.inflate(layoutInflater)
@@ -25,6 +27,16 @@ class MainActivity : AppCompatActivity() {
             // Test RecyclerXRay
             adapter = RecyclerXRay.wrap(sampleAdapter)
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        adbToggleReceiver.register()
+    }
+
+    override fun onStop() {
+        adbToggleReceiver.unregister()
+        super.onStop()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
+++ b/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
+import com.friendoye.recyclerxray.AdbToggleReceiver
 import com.friendoye.recyclerxray.RecyclerXRay
 import com.friendoye.recyclerxray.sample.databinding.ActivityMainBinding
 

--- a/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
+++ b/sample/src/main/java/com/friendoye/recyclerxray/sample/MainActivity.kt
@@ -27,16 +27,8 @@ class MainActivity : AppCompatActivity() {
             // Test RecyclerXRay
             adapter = RecyclerXRay.wrap(sampleAdapter)
         }
-    }
 
-    override fun onStart() {
-        super.onStart()
-        adbToggleReceiver.register()
-    }
-
-    override fun onStop() {
-        adbToggleReceiver.unregister()
-        super.onStop()
+        lifecycle.addObserver(adbToggleReceiver)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {


### PR DESCRIPTION
Developer can now toggle state of `RecyclerXRay` with the help of `adb`. For that it needs:
1) Attach `AdbToggleReceiver` to `Activity/Application` lifecycler;
2) Enter this command in your command line: `adb shell am broadcast -a xray-toggle`